### PR TITLE
fix tests always "succeed"

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -42,10 +42,7 @@ def runtests():
         pass
 
     argv = [sys.argv[0], 'test']
-    try:
-        execute_from_command_line(argv)
-    except:
-        pass
-
+    return execute_from_command_line(argv)
+    
 if __name__ == '__main__':
-    runtests()
+    sys.exit(runtests())


### PR DESCRIPTION
The problem is that runtests.py used in tox always returns with exitcode 0 whatever happens. Tox (and in extension Travis) needs an exitcode != 0 to be able to know that something went wrong.